### PR TITLE
dbFS delta silence algorithm

### DIFF
--- a/snarp.py
+++ b/snarp.py
@@ -48,10 +48,10 @@ INPUT_SIGNEDNESS = None # None means permit Wave format rules to prevail
 # parameters. Note that all times must be multiples of CHUNK_MS, since
 # all audio processing is done in blocks of length CHUNK_MS. 
 # 
-CHUNK_MS      = 10  # milliseconds per silence analysis period
-HYSTERESIS_MS = 1000 # ms of silence before we decide audible segment is over
-PRE_ROLL_MS   = 500  # ms of silence to play at beginning of audible segment
-POST_ROLL_MS  = 500  # ms of silence to play at end of audible segment
+CHUNK_MS      = 1000   # milliseconds per silence analysis period
+HYSTERESIS_MS = 3000 # ms of silence before we decide audible segment is over
+PRE_ROLL_MS   = 1000  # ms of silence to play at beginning of audible segment
+POST_ROLL_MS  = 1000  # ms of silence to play at end of audible segment
 
 HYSTERESIS_CHUNKS = int(float(HYSTERESIS_MS) / CHUNK_MS)
 PRE_ROLL_CHUNKS   = int(float(PRE_ROLL_MS) / CHUNK_MS)

--- a/snarp.py
+++ b/snarp.py
@@ -169,13 +169,13 @@ def tag_segments(tagged_chunks):
 
                 # first, take any extra buffer and append to silent segment
                 for i in range(len(buffer) - PRE_ROLL_CHUNKS):
-                    logging.debug("Dumped excess buffer chunk to silent segment.")
+                    #logging.debug("Dumped excess buffer chunk to silent segment.")
                     yield False, buffer.popleft()
                     
                 # write out remainder of buffer as pre-roll
                 logging.debug("Pre-rolling...")
                 for frames in buffer:
-                    logging.debug("Pre-roll chunk written.")
+                    #logging.debug("Pre-roll chunk written.")
                     yield False, frames
                 buffer.clear()
 
@@ -188,7 +188,7 @@ def tag_segments(tagged_chunks):
                 # first few buffered chunks go to end of audible segment
                 for i in range(POST_ROLL_CHUNKS):
                     if len(buffer) > 0:
-                        logging.debug("Post-roll chunk written.")
+                        #logging.debug("Post-roll chunk written.")
                         yield False, buffer.popleft()
 
                 # any remaining buffer chunks should go to the silent segment
@@ -247,12 +247,12 @@ def tag_chunks(chunk_gen, silence_deltas):
         md, iqrd = max_ - min_, q3 - q1
 
         #logging.debug('max_delta: {0}, iqr_delta: {1}, silence: {2}'.format(max_ - min_, q3 - q1, silence))
-        logging.debug('{}% {}%, ({}, {}), silence: {}'.format(
-            int(100 * float(max_ - min_) / max_delta), 
-            int(100 * float(q3 - q1) / iqr_delta), 
-            md, iqrd,
-            silence
-        ))
+#        logging.debug('{}% {}%, ({}, {}), silence: {}'.format(
+#            int(100 * float(max_ - min_) / max_delta), 
+#            int(100 * float(q3 - q1) / iqr_delta), 
+#            md, iqrd,
+#            silence
+#        ))
 
         yield silence, chunk_samples, chunk_frames
 

--- a/snarp.py
+++ b/snarp.py
@@ -86,11 +86,30 @@ class RingBuffer(collections.deque):
 
 def audible_chunks(tagged_segments):
     '''
-    Generator returning chunk frames tagged by segment
+    Generator producing audio chunks only for audible segments
     '''
-    for silent_segment, chunk_frames in tagged_segments:
-        if not silent_segment:
-            yield chunk_frames
+    return itertools.imap(lambda pair: pair[1], 
+        itertools.ifilter(lambda pair: not pair[0], tagged_segments)
+    )
+
+def audible_segments(tagged_segments):
+    '''
+    Return generator of generators, one per audible segment
+
+    For each audible segment in the chunk stream, return a generator
+    for its audio data chunks.
+    '''
+    return (segment for silent, segment in segmenter(tagged_segments) if not silent)
+
+def segmenter(tagged_segments):
+    '''
+    Return generator of generators, one per segment
+
+    For each segment in the chunk stream, return a tuple of:
+        (segment_is_silent, chunk_generator_for_segment)
+    '''
+    for silent, segment in itertools.groupby(tagged_segments, key=lambda pair: pair[0]):
+        yield silent, itertools.imap(lambda pair: pair[1], segment)
 
 def tag_segments(tagged_chunks):
     '''

--- a/snarp.py
+++ b/snarp.py
@@ -48,10 +48,10 @@ INPUT_SIGNEDNESS = None # None means permit Wave format rules to prevail
 # parameters. Note that all times must be multiples of CHUNK_MS, since
 # all audio processing is done in blocks of length CHUNK_MS. 
 # 
-CHUNK_MS      = 1000   # milliseconds per silence analysis period
-HYSTERESIS_MS = 3000 # ms of silence before we decide audible segment is over
-PRE_ROLL_MS   = 1000  # ms of silence to play at beginning of audible segment
-POST_ROLL_MS  = 1000  # ms of silence to play at end of audible segment
+CHUNK_MS      = 100   # milliseconds per silence analysis period
+HYSTERESIS_MS = 1000 # ms of silence before we decide audible segment is over
+PRE_ROLL_MS   = 200  # ms of silence to play at beginning of audible segment
+POST_ROLL_MS  = 100  # ms of silence to play at end of audible segment
 
 HYSTERESIS_CHUNKS = int(float(HYSTERESIS_MS) / CHUNK_MS)
 PRE_ROLL_CHUNKS   = int(float(PRE_ROLL_MS) / CHUNK_MS)

--- a/test/test_snarp.py
+++ b/test/test_snarp.py
@@ -5,12 +5,15 @@ import os
 
 OUTPUT_FILENAME = "/tmp/output.wav"
 
+def assert_eq(a, b):
+	assert a == b, "{0!r} != {1!r}".format(a, b)
+
 def test_basic_functionality():
 	inputs = [
-		("test/data/generated-beeps-44k-16bit-1ch.wav", 262395, 174195),
-		("test/data/generated-beeps-44k-8bit-1ch.wav", 262395, 174195),
-		("test/data/generated-beeps-22k-16bit-1ch.wav", 131198, 87098),
-		("test/data/generated-beeps-22k-8bit-1ch.wav", 131198, 87098),
+		("test/data/generated-beeps-44k-16bit-1ch.wav", 262395, 55125),
+		("test/data/generated-beeps-44k-8bit-1ch.wav", 262395, 55125),
+		("test/data/generated-beeps-22k-16bit-1ch.wav", 131198, 27563),
+		("test/data/generated-beeps-22k-8bit-1ch.wav", 131198, 27563),
 	]
 	for filename, expected_input_frames, expected_output_frames in inputs:
 		check_basic_functionality(filename, expected_input_frames, expected_output_frames)
@@ -18,8 +21,8 @@ def test_basic_functionality():
 def check_basic_functionality(filename, expected_input_frames, expected_output_frames):
 	with open(filename, "rb") as input:
 		with open(OUTPUT_FILENAME, "wb+") as output:
-			with snarp.silence_limits(120, 135):
-				snarp.remove_silences(input, output)
+		#	with snarp.silence_limits(120, 135):
+			snarp.remove_silences(input, output)
 
 			input.seek(0)
 			output.seek(0)
@@ -27,13 +30,14 @@ def check_basic_functionality(filename, expected_input_frames, expected_output_f
 			wave_input = wave.open(input, 'rb')
 			wave_output = wave.open(output, 'rb')
 
+			print("Filename: {0}".format(filename))
 			print("Input is {0} frames long".format(wave_input.getnframes()))
 			print("Output is {0} frames long".format(wave_output.getnframes()))
 
 			# Given that we're using the correct test input file
-			assert(wave_input.getnframes() == expected_input_frames)
+			assert_eq(wave_input.getnframes(), expected_input_frames)
 			# Ensure we removed a consistent amount of silence
-			assert(wave_output.getnframes() == expected_output_frames)
+			assert_eq(wave_output.getnframes(), expected_output_frames)
 
 	# cleanup, delete temp output file
 	os.unlink(OUTPUT_FILENAME)

--- a/tools/analyze-requirements.txt
+++ b/tools/analyze-requirements.txt
@@ -1,0 +1,17 @@
+PyContracts==1.5.1
+PyGeometry==1.3
+altgraph==0.10.2
+configobj==4.7.2
+decorator==3.4.0
+distribute==0.6.27
+macholib==1.5.1
+matplotlib==1.2.1
+modulegraph==0.10.4
+mpltools==0.1
+numpy==1.7.1
+pandas==0.12.0
+pyproj==1.9.3
+python-dateutil==2.1
+pytz==2013d
+scipy==0.12.0
+six==1.4.1

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# coding=utf8
+'''
+Analyze chunk sample level stats from SNARP
+
+Run SNARP with the flag --stats-file to specify the filename to save
+CSV sample stats data to. Analye with
+
+    python analyze.py statsfile.csv
+
+You'll need the analysis dependencies in analyze-requirements.txt 
+installed.
+'''
+
+import pandas
+from pandas import Series, DataFrame
+import code
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+import csv
+
+if __name__ == '__main__':
+	with open("stats.csv" if len(sys.argv) < 2 else sys.argv[1]) as f:
+		reader = csv.reader(f)
+		data = [(float(peak), float(iqr)) for peak, iqr in reader]
+
+	md = Series(zip(*data)[0])
+	iqrd = Series(zip(*data)[1])
+
+	df = DataFrame(data=dict(max_deltas=md, iqr_deltas=iqrd))
+
+	#log_df = np.log(df) / np.log(2)
+	#log_df.columns = ["lg {}".format(foo) for foo in log_df.columns]
+	#log_df.hist(normed=True)
+
+	df.hist(normed=True)
+
+	plt.show()
+
+	code.interact(local=locals())
+


### PR DESCRIPTION
This is the second of two pull requests in sequence. Here, I've modified the silence detection algorithm. 

Rather than specifying absolute SILENCE_MIN and SILENCE_MAX values, I'm measuring the delta between the max_ and min_ sample values. By specifying that delta as a silence limit, we don't have to worry about DC offsets – that is, when the signal is not centered on 0 (or 127, for 8 bit unsigned audio). 

For additional robustness, I've added a second "delta" range measurement: the IQR, or inter-quartile range of the samples in the chunk. This is just the limits of the middle 50% of the sample values, and since sound is generally symmetric across the zero point, is effectively a measurement of the range of the 50th percentile of the sample values. 

The IQR is far less susceptible to transient noise than the overall peak to peak range. Since I'm allowing either the peak or IQR setting to declare a chunk "audible," you can set a much more conservative peak delta, avoiding false positives from transient yet loud crackles, and a more liberal IQR delta, avoiding missing legitimate audible noise, which should be long enough in duration to raise the IQR, which truly transient noise should do less so. 

Finally, I've then converted the input values for these ranges into decibels against the full scale, or dbFS. This just means that rather than having to convert your silence limits for every different sample width, you can just specify a ratio of the overall sample range. 

For instance, if you wanted to set your peak limit at a signal that used 50% of the entire sample range (way too loud in real life!), you'd just say -6 dBFS. Whether that sample width is 8 bits or 16 bits, the dBFS is a ratio of the total sample width, so it need not be converted. As decibel values, they're also logarithmic, so scale intuitively when dealing with noise volume. 

I've also added some logging and analysis of these peak and IQR dBFS values, making it easier to analyze a sample of your source audio and see on a histogram where the noise and silence cutoffs should be. Here's a screenshot of such a histogram: 

![figure_squelched_audio_deltas](https://f.cloud.github.com/assets/349839/1135857/f6d7be8c-1c26-11e3-9df5-531b60049359.png)

These histograms are for a radio recording I took this evening of sporadic narrow band FM traffic. The output was squelched by the radio receiver, which is why there's a hard spike near -50 dBFS, the minimum possible for this sample width. The signal also clipped, due to too much gain in the receiver configuration, so you see peak-to-peak ranges up around 0 dBFS. 

The clear and wide gap between the histogram peaks for silence and noise make this an easy source to segment based on silence. Non-squelched microphone recordings with background noise have much less room for error, and the histograms can help find the silence/noise split. 
