### PR TITLE
Generator tagging and segmentation

### DIFF
--- a/snarp.py
+++ b/snarp.py
@@ -48,10 +48,10 @@ INPUT_SIGNEDNESS = None # None means permit Wave format rules to prevail
 # parameters. Note that all times must be multiples of CHUNK_MS, since
 # all audio processing is done in blocks of length CHUNK_MS. 
 # 
-CHUNK_MS      = 10  # milliseconds per silence analysis period
-HYSTERESIS_MS = 1000 # ms of silence before we decide audible segment is over
-PRE_ROLL_MS   = 500  # ms of silence to play at beginning of audible segment
-POST_ROLL_MS  = 500  # ms of silence to play at end of audible segment
+CHUNK_MS      = 1000   # milliseconds per silence analysis period
+HYSTERESIS_MS = 3000 # ms of silence before we decide audible segment is over
+PRE_ROLL_MS   = 1000  # ms of silence to play at beginning of audible segment
+POST_ROLL_MS  = 1000  # ms of silence to play at end of audible segment
 
 HYSTERESIS_CHUNKS = int(float(HYSTERESIS_MS) / CHUNK_MS)
 PRE_ROLL_CHUNKS   = int(float(PRE_ROLL_MS) / CHUNK_MS)

--- a/snarp.py
+++ b/snarp.py
@@ -86,11 +86,30 @@ class RingBuffer(collections.deque):
 
 def audible_chunks(tagged_segments):
     '''
-    Generator returning chunk frames tagged by segment
+    Generator producing audio chunks only for audible segments
     '''
-    for silent_segment, chunk_frames in tagged_segments:
-        if not silent_segment:
-            yield chunk_frames
+    return itertools.imap(lambda pair: pair[1], 
+        itertools.ifilter(lambda pair: not pair[0], tagged_segments)
+    )
+
+def audible_segments(tagged_segments):
+    '''
+    Return generator of generators, one per audible segment
+
+    For each audible segment in the chunk stream, return a generator
+    for its audio data chunks.
+    '''
+    return (segment for silent, segment in segmenter(tagged_segments) if not silent)
+
+def segmenter(tagged_segments):
+    '''
+    Return generator of generators, one per segment
+
+    For each segment in the chunk stream, return a tuple of:
+        (segment_is_silent, chunk_generator_for_segment)
+    '''
+    for silent, segment in itertools.groupby(tagged_segments, key=lambda pair: pair[0]):
+        yield silent, itertools.imap(lambda pair: pair[1], segment)
 
 def tag_segments(tagged_chunks):
     '''


### PR DESCRIPTION
This is the first of two sequential pull request I have ready. I've split them since they deal with different concerns, and this should make them a little easier to look over. (Note, I accidentally submitted these out of order).

First, in this branch, I've changed the audio processing code. Rather than looping over chunks of samples indefinitely, I've push all the audio parsing, chunking, silence detection, and chunk segmentation into generators. 

Effectively, instead of doing `while True: ... <convert> ... <split> ... <buffer> ... <detect silence> ... <maybe write>`, we can do things like: 

``` python
        for chunk_frames in \
            audible_chunks(tag_chunks(chunked_samples(input_wave, CHUNK_SECONDS))):

            output_wave.writeframes(chunk_frames)
```

Note that this is not the actual logic used in the latest remove_silences(); this is the logic as it was in commit 8073e2417, after which things got more complicated again. 

Since that commit, I added more sophisticated segmentation. That is, rather than just writing audio when we see noise, and not writing when we see silence, I'm tagging each chunk as to whether it belongs to an audible or silent "segment" (note that it's entirely possible for a silent _chunk_ to be part of an audible *segment• – for example, the pre-roll or post-roll). 

The `audible_chunks()` function seen above utilizes this tagging to suppress silences and write audible segments. 

However, we can now do more: The option I've immediately added in this pull request is to _also_ write the silent chunks. This lets us write out a "bypass" stream which is an exact copy of the audio input. While this could be done outside the program, e.g. with the `tee` UNIX filter, I think it's appropriate to include since it essentially offers an archival option if you've, for instance, set your silence limits incorrectly. This is also convenient for running SNARP multiple times on the same input for testing. 

My primary motivation for this change in model to "silent" and "audible" segments is that I ultimately intend to add the ability to write each audible segment out as a separate, timestamped audio file. Having segmented the audio stream this way, this per-file behavior will be easy to implement. 

Segregating the pre- and post-roll buffering from the silence detection and other logic has another benefit: We can increase the complexity of the buffering/silent-or-audible-segement logic without tripping over the other features. You'll note that the biggest single expansion of the code is in this `tag_segments()` function.

What I've done is: 
- Separated the concept of chunk length from hysteresis. i.e. we can say an audible segment only ends after one full second of silence, yet only write out one 100 ms chunk as a post roll buffer.
- Allowed different, specific pre- and post- roll buffer lengths.
- Managed the "pre-roll-buffer," now just a general buffer, so we never lose samples e.g. when the script ends, or when there's a bunch of silence in the middle of an audible segment. 

Put together, these basically give us "look-ahead" capability, so we can keep the pre- and post-rolls short yet still have smooth noise detection. 

Finally, one of the first commits in this branch fixes a few performance issues my first pull request introduced. I did a bunch of profiling work, and moved all the unnecessary metadata and configuration stuff (e.g. computation of the signedness based on sample width) out of the inner loop. 
